### PR TITLE
feat: add share component fallback

### DIFF
--- a/src/components/Dashboard/UrlList/Items.tsx
+++ b/src/components/Dashboard/UrlList/Items.tsx
@@ -25,6 +25,7 @@ import { IUrlListProps } from 'components/Dashboard/UrlList'
 import { ErrorDataNotFound } from 'components/Error/ErrorDataNotFound'
 import { LoadingSkeleton } from './LoadingSkeleton'
 import { IUrl } from 'interfaces/IUrl'
+import SharePopover from './SharePopover'
 
 const copy: any = dynamic((): any => import('copy-to-clipboard'), { ssr: false })
 
@@ -209,15 +210,19 @@ export function Items({ user, isFormVisible, onShowForm }: IUrlListProps) {
                   variant="ghost"
                   icon={<HiDuplicate color="#ED8936" />}
                 />
-                <IconButton
-                  onClick={() => {
-                    handleShare(`${HOME}${d.slug}`)
-                  }}
-                  aria-label="Copy"
-                  fontSize="20px"
-                  variant="ghost"
-                  icon={<HiShare color="#ED8936" />}
-                />
+                {navigator.share !== undefined ? (
+                  <IconButton
+                    onClick={() => {
+                      handleShare(`${HOME}${d.slug}`)
+                    }}
+                    aria-label="Copy"
+                    fontSize="20px"
+                    variant="ghost"
+                    icon={<HiShare color="#ED8936" />}
+                  />
+                ) : (
+                  <SharePopover url={`${HOME}${d.slug}`} />
+                )}
                 <IconButton
                   onClick={() => {
                     handleClickEdit(d.id)

--- a/src/components/Dashboard/UrlList/Items.tsx
+++ b/src/components/Dashboard/UrlList/Items.tsx
@@ -33,6 +33,8 @@ export function Items({ user, isFormVisible, onShowForm }: IUrlListProps) {
   const { showAlert, hideAlert } = useAlertContext()
   const [updateId, setUpdateId] = useState<string>('')
   const [updateSlug, setUpdateSlug] = useState<string>('')
+  const isSupportShare: boolean =
+    typeof window !== 'undefined' ? navigator.share !== undefined : false
 
   const bgBox = useColorModeValue('white', 'gray.800')
   const bgInput = useColorModeValue('blackAlpha.100', 'whiteAlpha.100')
@@ -210,7 +212,7 @@ export function Items({ user, isFormVisible, onShowForm }: IUrlListProps) {
                   variant="ghost"
                   icon={<HiDuplicate color="#ED8936" />}
                 />
-                {navigator.share !== undefined ? (
+                {isSupportShare ? (
                   <IconButton
                     onClick={() => {
                       handleShare(`${HOME}${d.slug}`)

--- a/src/components/Dashboard/UrlList/SharePopover.tsx
+++ b/src/components/Dashboard/UrlList/SharePopover.tsx
@@ -35,6 +35,7 @@ const SharePopover = ({ url }: SharePopoverProps) => {
       onClose={() => {
         setShowShare(false)
       }}
+      isLazy
       placement="bottom"
     >
       <PopoverTrigger>

--- a/src/components/Dashboard/UrlList/SharePopover.tsx
+++ b/src/components/Dashboard/UrlList/SharePopover.tsx
@@ -1,0 +1,83 @@
+import {
+  IconButton,
+  Link,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverHeader,
+  PopoverBody,
+  PopoverArrow,
+  PopoverCloseButton,
+  Stack
+} from '@chakra-ui/react'
+import { HiShare } from 'react-icons/hi'
+import { FaFacebook, FaTwitter, FaWhatsapp } from 'react-icons/fa'
+import { useState } from 'react'
+
+type SharePopoverProps = {
+  url: string
+}
+
+const SharePopover = ({ url }: SharePopoverProps) => {
+  const [showShare, setShowShare] = useState<boolean>(false)
+  const [text, setText] = useState<string>('')
+  const parsedUrl = encodeURIComponent(url)
+  const handleShare = async (url: string) => {
+    const res = await fetch(`https://oge.now.sh/api?url=${decodeURIComponent(url)}`)
+    const d = await res.json()
+    setText(encodeURIComponent(d.description))
+    setShowShare(true)
+  }
+
+  return (
+    <Popover
+      isOpen={showShare}
+      onClose={() => {
+        setShowShare(false)
+      }}
+      placement="bottom"
+    >
+      <PopoverTrigger>
+        <IconButton
+          onClick={() => {
+            handleShare(url)
+          }}
+          aria-label="Copy"
+          fontSize="20px"
+          variant="ghost"
+          icon={<HiShare color="#ED8936" />}
+        />
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader>Bagikan tautan anda</PopoverHeader>
+        <PopoverBody>
+          <Stack direction="row" justifyContent="center">
+            <Link
+              isExternal
+              href={`https://twitter.com/intent/tweet?text=${text}+%0A+${parsedUrl}`}
+            >
+              <IconButton colorScheme="twitter" aria-label="Share twitter" icon={<FaTwitter />} />
+            </Link>
+            <Link isExternal href={`https://api.whatsapp.com/send?text=${text}+%0A+${parsedUrl}`}>
+              <IconButton colorScheme="green" aria-label="Share whatsapp" icon={<FaWhatsapp />} />
+            </Link>
+            <Link
+              isExternal
+              href={`https://www.facebook.com/sharer/sharer.php?quote=${text}&u=${parsedUrl}`}
+            >
+              <IconButton
+                colorScheme="facebook"
+                aria-label="Share Facebook"
+                icon={<FaFacebook />}
+              />
+            </Link>
+          </Stack>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export default SharePopover

--- a/src/components/Dashboard/UrlList/SharePopover.tsx
+++ b/src/components/Dashboard/UrlList/SharePopover.tsx
@@ -42,7 +42,7 @@ const SharePopover = ({ url }: SharePopoverProps) => {
           onClick={() => {
             handleShare(url)
           }}
-          aria-label="Copy"
+          aria-label="Share url"
           fontSize="20px"
           variant="ghost"
           icon={<HiShare color="#ED8936" />}


### PR DESCRIPTION
### Description:

This PR adds a fallback component if `navigator.share` not supported.
Using chakra-ui [popover](https://chakra-ui.com/docs/overlay/popover)
Social media URL API (i found on internet) https://gist.github.com/HoldOffHunger/1998b92acb80bc83547baeaff68aaaf4


### Issue Reference

https://github.com/mazipan/ksana.in/issues/21

### Screenshoot

![image](https://user-images.githubusercontent.com/35674157/122647940-f7358200-d150-11eb-8f96-883b56d104e8.png)
![image](https://user-images.githubusercontent.com/35674157/122647945-00265380-d151-11eb-888a-97afabd65293.png)


### Minimum Support

- [x] Click 🌟 button to this repo
- [x] Follow the Author

### Consider to Support

- 👉 🇮🇩 [Trakteer](https://trakteer.id/mazipan?utm_source=github)
- 👉 🌍 [BuyMeACoffe](https://www.buymeacoffee.com/mazipan?utm_source=github)
- 👉 🌍 [Paypal](https://www.paypal.me/mazipan?utm_source=github)
- 👉 🌍 [Ko-Fi](https://ko-fi.com/mazipan)
